### PR TITLE
Should fix "UTF-8 file with BOM causes DateTime.Parse to fail"

### DIFF
--- a/Diplo.TraceLogViewer/Services/LogDataService.cs
+++ b/Diplo.TraceLogViewer/Services/LogDataService.cs
@@ -10,7 +10,7 @@ using Diplo.TraceLogViewer.Models;
 
 namespace Diplo.TraceLogViewer.Services
 {
-	/// <summary>
+    /// <summary>
 	/// Used to query trace log data from trace log files
 	/// </summary>
 	/// <remarks>
@@ -26,6 +26,8 @@ namespace Diplo.TraceLogViewer.Services
 		//The last group in the match will have the thread number
 		private const string ThreadNumberPattern = @"((.+) (\[\d+\]) (.+) (\[Thread (\d+)\] ?))";
 		private static readonly Regex ThreadNumberRegex = new Regex(ThreadNumberPattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+        private readonly string _byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
 
 		/// <summary>
 		/// Gets a collection of log file data items from a given log filename
@@ -50,7 +52,9 @@ namespace Diplo.TraceLogViewer.Services
 
 			if (File.Exists(logFilePath))
 			{
-				string log = File.ReadAllText(logFilePath, Encoding.UTF8);
+				string log = File.ReadAllText(logFilePath);
+			    if (log.StartsWith(_byteOrderMarkUtf8))
+			        log = log.Remove(0, _byteOrderMarkUtf8.Length);
 
 				var allLines = log.Split('\n');
 


### PR DESCRIPTION
See: http://our.umbraco.org/projects/developer-tools/diplo-trace-log-viewer/diplo-trace-log-viewer/56620-UTF-8-file-with-BOM-causes-DateTimeParse-to-fail
Now fixed using this method: http://stackoverflow.com/a/4172005/5018
