### PR TITLE
The Regex needs an update for v7.3

### DIFF
--- a/BuildPackage/Package.build.xml
+++ b/BuildPackage/Package.build.xml
@@ -16,7 +16,7 @@
 
   <!-- PROPERTIES -->
   <PropertyGroup >
-    <BasePackageVersion>2.1.1.0</BasePackageVersion>
+    <BasePackageVersion>2.1.2.0</BasePackageVersion>
     <VersionSuffix></VersionSuffix>
     <MinUmbracoVersion>7.1.3</MinUmbracoVersion>
   </PropertyGroup>

--- a/Diplo.TraceLogViewer/Models/LogDataItem.cs
+++ b/Diplo.TraceLogViewer/Models/LogDataItem.cs
@@ -22,5 +22,9 @@ namespace Diplo.TraceLogViewer.Models
 		public string ThreadId { get; set; }
 
 		public string Message { get; set; }
+
+        public string ProcessId { get; set; }
+
+        public string AppDomainId { get; set; }
 	}
 }

--- a/Diplo.TraceLogViewer/Properties/AssemblyInfo.cs
+++ b/Diplo.TraceLogViewer/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
-[assembly: AssemblyInformationalVersion("2.1.1")]
+// [assembly: AssemblyVersion("2.1.2.0")]
+[assembly: AssemblyVersion("2.1.2.0")]
+[assembly: AssemblyFileVersion("2.1.2.0")]
+[assembly: AssemblyInformationalVersion("2.1.2")]

--- a/Umbraco7.1.3/App_Plugins/DiploTraceLogViewer/backoffice/diplotracelog/detail.html
+++ b/Umbraco7.1.3/App_Plugins/DiploTraceLogViewer/backoffice/diplotracelog/detail.html
@@ -68,6 +68,14 @@
                 <td><strong>No:</strong> {{ dialogData.ThreadNo }} , <strong>Id:</strong> {{ dialogData.ThreadId }}</td>
             </tr>
             <tr>
+                <th>Process</th>
+                <td><strong>Id:</strong> {{ dialogData.ProcessId }}</td>
+            </tr>
+            <tr>
+                <th>AppDomain</th>
+                <td><strong>Id:</strong> {{ dialogData.AppDomainId }}</td>
+            </tr>
+            <tr>
                 <td colspan="2" class="message">{{ dialogData.Message }}</td>
             </tr>
             <tr>


### PR DESCRIPTION
The digits in square brackets will now change into digits+alpha characters, breaking the regex parsing

New log message will have ProcessId, AppDomainId and ThreadId in one block, parse them and show them in appropriate fields

I've tested this with old and new style log messages (examples in the source code comments) and all combinations still work, newer style logs obviously have the extra `[P22252/D3/T67]` info in them which is now parsed correctly.

FYI the current version breaks completely as `[P22252/D3/T67]` doesn't match the `[(\d+)\]` regex as there's now some alphabet characters in there.