### PR TITLE
Tell MSBuild to build in Release mode

### DIFF
--- a/BuildPackage/Build.bat
+++ b/BuildPackage/Build.bat
@@ -1,2 +1,2 @@
 Call nuget.exe restore ..\DiploTraceLogViewer.sln
-Call "C:\Program Files (x86)\MSBuild\12.0\Bin\MsBuild.exe" Package.build.xml
+Call "C:\Program Files (x86)\MSBuild\12.0\Bin\MsBuild.exe" Package.build.xml /p:Configuration=Release


### PR DESCRIPTION
Else the Release folder won't be there if you've never built in Release mode in VS

The previous version would build in the Debug directory! So you'd never get a clean build, just the same build you ran in VS earlier