### PR TITLE
Disclose less information in exception, allow access only to people w…

### DIFF
--- a/BuildPackage/Package.build.xml
+++ b/BuildPackage/Package.build.xml
@@ -16,7 +16,7 @@
 
   <!-- PROPERTIES -->
   <PropertyGroup >
-    <BasePackageVersion>2.2.1.0</BasePackageVersion>
+    <BasePackageVersion>2.2.2.0</BasePackageVersion>
     <VersionSuffix></VersionSuffix>
     <MinUmbracoVersion>7.1.3</MinUmbracoVersion>
   </PropertyGroup>

--- a/Diplo.TraceLogViewer/Controllers/TraceLogController.cs
+++ b/Diplo.TraceLogViewer/Controllers/TraceLogController.cs
@@ -7,12 +7,15 @@ using Umbraco.Web.WebApi;
 using Diplo.TraceLogViewer.Models;
 using Diplo.TraceLogViewer.Services;
 using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
+using Umbraco.Web.WebApi.Filters;
 
 namespace Diplo.TraceLogViewer.Controllers
 {
 	/// <summary>
 	/// Controller for accessing Umbraco trace log data
 	/// </summary>
+    [UmbracoApplicationAuthorize("developer")]
 	[PluginController("TraceLogViewer")]
 	public class TraceLogController : UmbracoAuthorizedApiController
 	{

--- a/Diplo.TraceLogViewer/Controllers/TraceLogTreeController.cs
+++ b/Diplo.TraceLogViewer/Controllers/TraceLogTreeController.cs
@@ -15,6 +15,7 @@ using umbraco.BusinessLogic.Actions;
 using umbraco;
 using System.Web.Http;
 using System.Net;
+using Umbraco.Web.WebApi.Filters;
 
 namespace Diplo.TraceLogViewer.Controllers
 {
@@ -24,6 +25,7 @@ namespace Diplo.TraceLogViewer.Controllers
 	/// <remarks>
 	/// Creates the tree for the tracelogs, with each logfile as a separate node
 	/// </remarks>
+    [UmbracoApplicationAuthorize("developer")]
 	[Tree(Constants.Applications.Developer, "diploTraceLog", "Trace Logs", sortOrder:9)]
 	[PluginController("DiploTraceLogViewer")]
 	public class TraceLogTreeController : TreeController

--- a/Diplo.TraceLogViewer/Properties/AssemblyInfo.cs
+++ b/Diplo.TraceLogViewer/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyFileVersion("2.2.1.0")]
-[assembly: AssemblyInformationalVersion("2.2.1")]
+// [assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyFileVersion("2.2.2.0")]
+[assembly: AssemblyInformationalVersion("2.2.2")]

--- a/Diplo.TraceLogViewer/Services/LogDataService.cs
+++ b/Diplo.TraceLogViewer/Services/LogDataService.cs
@@ -37,7 +37,7 @@ namespace Diplo.TraceLogViewer.Services
         public IEnumerable<LogDataItem> GetLogDataFromFile(string fileName)
         {
             string fullPath = HostingEnvironment.MapPath(Path.Combine(LogFileService.BaseLogPath, fileName));
-            return GetLogData(fullPath);
+            return GetLogData(fullPath, fileName);
         }
 
         /// <summary>
@@ -45,7 +45,19 @@ namespace Diplo.TraceLogViewer.Services
         /// </summary>
         /// <param name="logFilePath">The full file path to the log file</param>
         /// <returns>An enumerable collection of log file data</returns>
+        [Obsolete("Please use GetLogData(logFilePath, fileName instead)", false)]
         public IEnumerable<LogDataItem> GetLogData(string logFilePath)
+        {
+            return GetLogData(logFilePath, "");
+        }
+
+        /// <summary>
+        /// Gets a collection of log file data items from a given filepath to a log file
+        /// </summary>
+        /// <param name="logFilePath">The full file path to the log file</param>
+        /// <param name="fileName">The filename of the log file</param>
+        /// <returns>An enumerable collection of log file data</returns>
+        public IEnumerable<LogDataItem> GetLogData(string logFilePath, string fileName)
         {
             var logItems = new List<LogDataItem>();
 
@@ -135,7 +147,7 @@ namespace Diplo.TraceLogViewer.Services
             }
             else
             {
-                throw new FileNotFoundException("The requested trace log file '" + logFilePath + "' could not be found", logFilePath);
+                throw new FileNotFoundException("The requested trace log file '" + fileName + "' could not be found", fileName);
             }
 
             return logItems;


### PR DESCRIPTION
…ith access to developer section

I've done two things to improve security after getting a report back from a pen-testing firm:
1. The error thrown when a log file was not found disclosed the whole path of the file not found. Arguably there's other ways to get the path if you do have access to the developer section but this also helps with people copy-pasting details into public issue trackers. I don't know how you want to deal with breaking changes to public methods so I made it fully backwards compatible. I would've preferred to move `string fullPath = HostingEnvironment.MapPath(Path.Combine(LogFileService.BaseLogPath, fileName));` into `GetLogData` and only give `GetLogData` the relative path. Let me know if you want to update that.
2. Both controllers had methods that would disclose information to users who did not have access to the developer section. I've tested before and after this fix and it's now no longer possible to access any of those methods unless you have access to the developer section.

Thanks! Seb.