### PR TITLE
More efficient reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ obj/
 /packages/
 
 BuildPackage/Package/*
+.DiploTraceLogViewer.boltdata/*

--- a/Diplo.TraceLogViewer.Tests/Umbraco72xTests.cs
+++ b/Diplo.TraceLogViewer.Tests/Umbraco72xTests.cs
@@ -93,6 +93,8 @@ namespace Diplo.TraceLogViewer.Tests
             TimeSpan totalStream = TimeSpan.Zero;
             TimeSpan totalReadAll = TimeSpan.Zero;
             Stopwatch sw = new Stopwatch();
+            int countReadAll = 0;
+            int countStream = 0;
 
             var file = Configuration.UmbracoBigFile; // the big file to use
 
@@ -106,7 +108,9 @@ namespace Diplo.TraceLogViewer.Tests
 
                 LogDataService dataService = new LogDataService();
 
-                var logData = dataService.GetLogDataFromFilePath(logFile);
+                countReadAll = dataService.GetLogDataFromFilePath(logFile)
+                    //It's IEnumerable = lazy executed so we need to iterate it
+                    .Count();
                 sw.Stop();
 
                 totalReadAll = totalReadAll.Add(sw.Elapsed);
@@ -122,7 +126,9 @@ namespace Diplo.TraceLogViewer.Tests
 
                 LogDataService dataService = new LogDataService();
 
-                var logData = dataService.GetLogDataStreamFromFilePath(logFile);
+                countStream = dataService.GetLogDataStreamFromFilePath(logFile)
+                    //It's IEnumerable = lazy executed so we need to iterate it
+                    .Count();
                 sw.Stop();
 
                 totalStream = totalStream.Add(sw.Elapsed);
@@ -140,6 +146,8 @@ namespace Diplo.TraceLogViewer.Tests
             {
                 TestContext.WriteLine("Read Stream is faster than Read All by {0}", totalReadAll - totalStream);
             }
+
+            Assert.AreEqual(countReadAll, countStream);
 
         }
 


### PR DESCRIPTION
This does a few things:

* makes the regex Compiled = this instantly takes a couple seconds off the processing time
* removes unused code (i.e. date formats)
* changes how the reader works to use a TextReader
* removes the manual splitting log file into separate lines with \r = this actually would add 2x as many strings into memory. TextReader can read lines correcty.
* removes all of the logic that was used for reading the stream - the logic is exactly the same as reading all of the lines one by one
* changes the logic of reading line by line to not store a huge List of items in memory and instead yield return the items when required, only keeps a tiny list item in memory at a time to track newline entries for single log entries
     * The other problem with this giant in memory list was that it was doing a `list.Last().Message = ` which means that for every real log entry it would have to iterate over every item in the entire list to find the last one and then change the entry, this is N+1.

The processing time for both is now basically the same (my tests show reading from the stream is slightly faster). Reading from the stream will ultimately use less memory instead of putting a big string into memory.