### PR TITLE
Read log path from log4net.config

### DIFF
--- a/Diplo.TraceLogViewer/Services/LogDataService.cs
+++ b/Diplo.TraceLogViewer/Services/LogDataService.cs
@@ -37,7 +37,7 @@ namespace Diplo.TraceLogViewer.Services
         /// <returns>An enumerable collection of log file data</returns>
         public IEnumerable<LogDataItem> GetLogDataFromDefaultFilePath(string fileName)
         {
-            string logFilePath = HostingEnvironment.MapPath(Path.Combine(LogFileService.BaseLogPath, fileName));
+            string logFilePath = Path.Combine(LogFileService.BaseLogPath, fileName);
 
             return GetLogDataFromFilePath(logFilePath);
         }


### PR DESCRIPTION
Replaced the hardcoded log path with the path configured in the log4net configuration file.

At our company we have configured Umbraco to log to a different location then the default. Your plugin currently didn't support this, hence the pull request. The Umbraco default configuration still works with this change.

Example of our Config/log4net.config file:

    <?xml version="1.0"?>
    <log4net>
      
      <root>
        <priority value="Info"/>
        <appender-ref ref="AsynchronousLog4NetAppender" />
      </root>
    
      <appender name="rollingFile" type="log4net.Appender.RollingFileAppender">	  
        <file type="log4net.Util.PatternString" value="E:\Log\BetereWereld\UmbracoTraceLog.%property{log4net:HostName}.txt" />
    ...

I hope this is something you are willing to add.

Regards,
Jeffrey