### PR TITLE
Allow for wider range of file names

### DIFF
--- a/Diplo.TraceLogViewer.Tests/LogFileServiceTests.cs
+++ b/Diplo.TraceLogViewer.Tests/LogFileServiceTests.cs
@@ -28,7 +28,8 @@ namespace Diplo.TraceLogViewer.Tests
                 @"F:\Kittens\Pictures\App_Data\Logs\UmbracoTraceLog.MachineName.txt.2016-01-04",
                 @"E:\Diplo\Some Path\\Logs\UmbracoTraceLog.MachineName.TXT.2016-01-15",
                 @"E:\Diplodocus\another\banana\App_Data\Logs\UmbracoTraceLog.Machine.Name.txt.2016-01-16",
-                @"E:\Diplo\Some Path\App_Data\Logs\UmbracoTraceLog.MictPHC124-PC.txt.2014-11-19"
+                @"E:\Diplo\Some Path\App_Data\Logs\UmbracoTraceLog.MictPHC124-PC.txt.2014-11-19",
+                @"g:\iis-logs\logfiles\site-name\umbraco\Umbraco.2013-09-14.txt",
             };
 
             invalidDummyLogFileNames = new string[]
@@ -36,7 +37,8 @@ namespace Diplo.TraceLogViewer.Tests
                 @"E:\Diplo\Some Path\App_Data\Logs\SomeOtherFile.txt",
                 @"E:\Kittens\Some Path\App_Data\Logs\UmbracoTraceLog.txt.bak",
                 @"E:\Diplo\Some Path\App_Data\Logs\UmbracoTraceLog.txt.2015-10-01.bak",
-                @"E:\Diplo\Some Path\App_Data\Logs\UmbracoTraceLog.txt.2015-15-01"
+                @"E:\Diplo\Some Path\App_Data\Logs\UmbracoTraceLog.txt.2015-15-01",
+                @"g:\iis-logs\logfiles\site-name\umbraco\Umbraco.2013-09-14.2013-09-14.txt"
             };
 
             allDummyLogFileNames = new List<string>(validDummyLogFileNames);
@@ -58,7 +60,7 @@ namespace Diplo.TraceLogViewer.Tests
                 TestContext.WriteLine(logItem);
             }
 
-            Assert.That(logItems.Count, Is.EqualTo(8));
+            Assert.That(logItems.Count, Is.EqualTo(9));
 
             Assert.That(logItems[0].Date.Date == DateTime.Today);
             Assert.That(Path.GetFileName(logItems[0].Path) == "UmbracoTraceLog.txt");
@@ -75,6 +77,10 @@ namespace Diplo.TraceLogViewer.Tests
             Assert.That(logItems[7].Date.Date == DateTime.Parse("2014-11-19"));
             Assert.That(Path.GetFileName(logItems[7].Path) == "UmbracoTraceLog.MictPHC124-PC.txt.2014-11-19");
             Assert.That(logItems[7].MachineName == "MictPHC124-PC");
+
+            Assert.That(logItems[8].Date.Date == DateTime.Parse("2013-09-14"));
+            Assert.That(Path.GetFileName(logItems[8].Path) == "Umbraco.2013-09-14.txt");
+            Assert.That(logItems[8].MachineName == null);
         }
     }
 }

--- a/Diplo.TraceLogViewer/Services/LogFileService.cs
+++ b/Diplo.TraceLogViewer/Services/LogFileService.cs
@@ -15,17 +15,35 @@ namespace Diplo.TraceLogViewer.Services
     /// </summary>
     public class LogFileService
     {
-        private const string filePattern = @".*UmbracoTraceLog.*(\.txt|\d{4}-\d{2}-\d{2})$"; // matches valid log file name
-        private const string datePattern = @".txt.(\d{4}-\d{2}-\d{2})"; // matches date pattern in log file name
-        private const string machinePattern = @"UmbracoTraceLog\.(.+)\.txt?.+";
-        private const string defaultLogPath = "~/App_Data/Logs/";
 
-        private static Regex filePatternRegex = new Regex(filePattern, RegexOptions.IgnoreCase);
-        private static Regex datePatternRegex = new Regex(datePattern, RegexOptions.IgnoreCase);
-        private static Regex machinePatternRegex = new Regex(machinePattern, RegexOptions.IgnoreCase);
+        private const string dateFormat = @"(?<date>\d{4}-\d{2}-\d{2})";
+        private static string defaultLogPath = "~/App_Data/Logs/";
+        private static string defautlLogFnPattern = "Umbraco(TraceLog)?";
 
+        private string filePattern = ""; // matches valid log file name      
+        private static string datePattern = ""; // matches date pattern in log file name
+        private static string machinePattern = ""; 
+        
+
+        private readonly Regex filePatternRegex; 
+        private readonly Regex datePatternRegex; 
+        private readonly Regex machinePatternRegex; 
         private static string baseLogPath;
+        private static string baseLogFilename;
 
+
+        public LogFileService()
+        {
+            datePattern = @"((" + dateFormat + ".txt)$|(txt." + dateFormat + ")$)";
+            machinePattern = @"(?<machine>((?!" + dateFormat + @").*))";
+            filePattern = @"(?<path>.*)"+
+                          @"(?<file>"+BaseLogFilename+@")\."+
+                          @"("+machinePattern+@"\.)?" +
+                          @"(" + datePattern+"|txt$)";
+                       
+            filePatternRegex = new Regex(filePattern, RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
+        }
+        
         /// <summary>
         /// Gets the absolute path to the folder where the logs are stored
         /// </summary>
@@ -37,6 +55,32 @@ namespace Diplo.TraceLogViewer.Services
             }
         }
 
+        public static string BaseLogFilename
+        {
+            get
+            {
+                return baseLogFilename ?? (baseLogFilename = ResolveBaseLogFileName());
+            }
+        }
+
+        private static string ResolveBaseLogFileName()
+        {
+            var loggerRepo = log4net.LogManager.GetRepository();
+            if (loggerRepo != null)
+            {
+                var appender =
+                    loggerRepo.GetAppenders().FirstOrDefault(a => "rollingFile".InvariantEquals(a.Name)) as
+                        RollingFileAppender;
+
+                if (appender != null)
+                {
+                    var fn = Path.GetFileName(appender.File);
+                    return fn.Split('.')[0];
+                }
+            }
+            return defautlLogFnPattern;
+        }
+
         /// <summary>
         /// Resolve the base log path, based on the log4net configured appenders.
         /// </summary>
@@ -44,17 +88,17 @@ namespace Diplo.TraceLogViewer.Services
         private static string ResolveBaseLogPath()
         {
             var loggerRepo = log4net.LogManager.GetRepository();
-
             if (loggerRepo != null)
             {
-                var appender = loggerRepo.GetAppenders().FirstOrDefault(a => "rollingFile".InvariantEquals(a.Name)) as RollingFileAppender;
+                var appender =
+                    loggerRepo.GetAppenders().FirstOrDefault(a => "rollingFile".InvariantEquals(a.Name)) as
+                        RollingFileAppender;
 
                 if (appender != null)
                 {
                     return Path.GetDirectoryName(appender.File);
                 }
             }
-
             return HostingEnvironment.MapPath(defaultLogPath);
         }
 
@@ -74,7 +118,7 @@ namespace Diplo.TraceLogViewer.Services
         /// <returns>A collection of log file items</returns>
         public IEnumerable<LogFileItem> GetLogFilesFromPath(string fullPath)
         {
-            var filenames = Directory.GetFiles(fullPath, "UmbracoTraceLog.*");
+            var filenames = Directory.GetFiles(fullPath, BaseLogFilename+".*");
             return GetDateSortedLogFileDataFromFileNames(filenames);
         }
 
@@ -101,24 +145,13 @@ namespace Diplo.TraceLogViewer.Services
                 if (fileMatch.Success)
                 {
                     var logDate = DateTime.Now;
-
-                    Match dateMatch = datePatternRegex.Match(f);
-
-                    if (dateMatch.Success && dateMatch.Groups.Count > 0)
+                    var date = fileMatch.Groups["date"].Value;
+                    if (!string.IsNullOrWhiteSpace(date) && !DateTime.TryParse(date, out logDate))
                     {
-                        if (!DateTime.TryParse(dateMatch.Groups[1].Value, out logDate))
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-
-                    Match machineMatch = machinePatternRegex.Match(f);
-
-                    if (machineMatch.Success && machineMatch.Groups.Count > 0)
-                    {
-                        machineName = machineMatch.Groups[1].Value;
-                    }
-
+                    var machineGroup = fileMatch.Groups["machine"].Value;
+                    machineName = string.IsNullOrWhiteSpace(machineGroup) ? null : machineGroup;
                     files.Add(new LogFileItem(logDate.Date, f, machineName));
                 }
             }


### PR DESCRIPTION
Using a single regex w/named groups to get date and machine name.
Try to get base file name from log4net config
Support "preserveLogFileNameExtension" flag 

Fix for issue #21 